### PR TITLE
Update rct_power.py

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/rct_power/rct_power.py
+++ b/FHEM/bindings/python/fhempy/lib/rct_power/rct_power.py
@@ -208,6 +208,14 @@ class rct_power(generic.FhemModule):
                 "function": "set_rct_write",
                 "function_param": 0x54829753,
             },
+             "island_only": {
+                "args": ["value"],
+                "params": {"value": {"format": "int"}},
+                "help": "Island without power switch support [Bool]. Boolean value 0 (Grid) or 1 (Island only, no Power Switch) is allowed.<br> !!!!! WARNING: Grid Power has to be cut off before switching. Check manual !!!! <br>Registry: power_mng.is_island_only",
+                "options": "slider,0,1,1",
+                "function": "set_rct_write",
+                "function_param": 0xC9900716,
+            },
         }
         self.set_set_config(set_config)
 


### PR DESCRIPTION
Hi Dominik, ich hätte gerne mal wieder einen neuen Befehl im Modul. Diesmal muss ein Bool-Wert gesendet werden. Da ich mir nicht sicher bin, ob man bool als Format angeben kann, habe ich "int" gewählt. Ist das ok ?

     "params": {"value": {"format": "int"}},

Vielen Dank und viele Grüße, Chris