### PR TITLE
Update manifest.json

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/skodaconnect/manifest.json
+++ b/FHEM/bindings/python/fhempy/lib/skodaconnect/manifest.json
@@ -3,6 +3,6 @@
     "pyjwt",
     "beautifulsoup4",
     "lxml",
-    "skodaconnect==1.3.7"
+    "skodaconnect==1.3.8"
   ]
 }


### PR DESCRIPTION
Bump skodaconnect to 1.3.8

This Version is needed:
"Updated User-Agent in order to get code on par with recent Android and IOS apps.

Outdated User-Agent from older app version seems to be blocked now at token endpoints. This change is confirmed working with Enyaq owners."