### PR TITLE
fix utils gen_fhemdev_name

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/utils.py
+++ b/FHEM/bindings/python/fhempy/lib/utils.py
@@ -188,7 +188,9 @@ def gen_reading_name(reading):
 
 
 def gen_fhemdev_name(devname):
-    return remove_special_charachters(devname.replace(" ", "_").replace("-", "_"))
+    return remove_special_charachters(
+        devname.replace(" ", "_").replace("-", "_").replace(":", "_")
+    )
 
 
 def remove_special_charachters(string):


### PR DESCRIPTION
fhem device name cannot contain `:`

found while on #292 