### PR TITLE
updated tibber requiment to pytibber v0.29.0 to fix broken tibber integration (issue  #398)

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/tibber/manifest.json
+++ b/FHEM/bindings/python/fhempy/lib/tibber/manifest.json
@@ -1,5 +1,5 @@
 {
   "requirements": [
-    "pyTibber==0.28.2"
+    "pyTibber==0.29.0"
   ]
 }


### PR DESCRIPTION
FIX

- fix(tibber) changed requirement pytibber to 0.29.0 in manifest.json