### PR TITLE
meross: Update manifest.json to fix "mfaLockExpired" exception

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/meross/manifest.json
+++ b/FHEM/bindings/python/fhempy/lib/meross/manifest.json
@@ -1,6 +1,6 @@
 {
   "requirements": [
-    "meross-iot==0.4.7.1",
+    "meross-iot==0.4.8.0",
     "setuptools==70.0.0"
   ]
 }


### PR DESCRIPTION
Getting mfaLockExpired due to a meross API change. Updating to 0.4.8.0 fixed it.

```
2025-02-25 10:35:13,272 - ERROR    - meross_integration: Exception raised by task: <Task finished name='Task-640' coro=<FhemModule._run_coro() done, defined at /opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/fhempy/lib/generic.py:216> exception=KeyError('mfaLockExpire')>
Traceback (most recent call last):
  File "/opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/fhempy/lib/generic.py", line 224, in _handle_task_result
    task.result()
  File "/opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/fhempy/lib/generic.py", line 218, in _run_coro
    await coro
  File "/opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/fhempy/lib/meross/meross_setup.py", line 28, in run_setup
    http_api_client = await MerossHttpClient.async_from_user_password(
  File "/opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/meross_iot/http_api.py", line 119, in async_from_user_password
    creds = await cls.async_login(email=email,
  File "/opt/fhem/.fhempy/fhempy_venv/lib/python3.9/site-packages/meross_iot/http_api.py", line 280, in async_login
    mfa_lock_expire=response_data["mfaLockExpire"],
KeyError: 'mfaLockExpire'
```