### PR TITLE
Fix: Make Kia/Hyundai login work again (for now)

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/kia_hyundai/kia_hyundai.py
+++ b/FHEM/bindings/python/fhempy/lib/kia_hyundai/kia_hyundai.py
@@ -77,8 +77,8 @@ class kia_hyundai(generic.FhemModule):
             self.username,
             self.password,
             self.pin,
-            geocode_api_enable=True,
-            geocode_api_use_email=True,
+            geocode_api_enable=False,
+            geocode_api_use_email=False,
         )
         while True:
             try:

--- a/FHEM/bindings/python/fhempy/lib/kia_hyundai/manifest.json
+++ b/FHEM/bindings/python/fhempy/lib/kia_hyundai/manifest.json
@@ -1,7 +1,6 @@
 {
   "requirements": [
-    "hyundai_kia_connect_api==3.19.1",
-    "pytz==2024.1",
+    "hyundai_kia_connect_api==4.21.0",    
     "python-dateutil==2.9.0.post0"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/fhempy/fhempy/issues/517

I bumped the hyundai kia api version to 4.21.0 and deactivated the geocode api (which made it work for me).

I'm open for further recommendations.